### PR TITLE
for it to iterate properly of the set_attr.. start on 0

### DIFF
--- a/maya_scenefile_parser/ascii.py
+++ b/maya_scenefile_parser/ascii.py
@@ -101,7 +101,7 @@ class MayaAsciiParserBase(common.MayaParserBase):
         attrtype = None
         value = None
 
-        argptr = 1
+        argptr = 0
         while argptr < len(args):
             arg = args[argptr]
             if arg in ("-type", "--type"):


### PR DESCRIPTION
for it to iterate properly of the set_attr.. I need to start on 0 to find the -type in the array..

---I tried it on a this maya asccii file, and had issues that it did not parse the translate and rotate correctly..

//Maya ASCII 2013 scene
//Name: Frame000001.ma
//Last modified: Thu, May 30, 2019 01:54:22
//Codeset: 1250
requires maya "2013";
currentUnit -l Meter -a degree -t pal;
createNode transform -n "Camera1";
	setAttr ".translate" -type "double3" -61.3705913218465 -72.9083740863482 27.44402042745573;
	setAttr ".rotate" -type "double3" 86.25937533399446 0.9089993643681026 -39.0049653572422;
createNode camera -n "cameraShape1" -p "Camera1";
	setAttr ".focalLength" 129.4273098880071;
	addAttr -ci true -sn "imageFileName" -ln "imageFileName" -dt "string";
	addAttr -ci true -sn "originalImageFileName" -ln "originalImageFileName" -dt "string";
	addAttr -ci true -sn "aspectRatio" -ln "aspectRatio" -at "double";
	addAttr -ci true -sn "principalPoint" -ln "principalPoint" -dt "double2";
	addAttr -ci true -sn "lensDistortion" -ln "lensDistortion" -dt "doubleArray";
	setAttr -k on ".imageFileName" -type "string" "Cam01_000001.jpg";
	setAttr -k on ".originalImageFileName" -type "string" "R:\\Frame000001\\Cam01_000001.jpg";
	setAttr -k on ".aspectRatio" -type double 1.000022599329786;
	setAttr -k on ".principalPoint" -type double2 0 -5.77383634949802e-017;
	setAttr -k on ".lensDistortion" -type doubleArray 6 0 0 0 0 0 0;
setAttr ".cap" -type "double2" 1.082607182989887 1.417322834645669 ;
